### PR TITLE
Update rango-ajax.js

### DIFF
--- a/code/tango_with_django_project/static/js/rango-ajax.js
+++ b/code/tango_with_django_project/static/js/rango-ajax.js
@@ -3,7 +3,7 @@
 		$('#likes').click(function(){
 		var catid;
 		catid = $(this).attr("data-catid");
-		$.get('/rango/like_category/', {category_id: catid}, function(data){
+		$.get('/rango/like/', {category_id: catid}, function(data){
 			$('#like_count').html(data);
 			$('#likes').hide();
 		});


### PR DESCRIPTION
Fixed wrong url  "like_category" to just "like", so ajax url to give a like "/rango/like/?category_id=6" become available.