### PR TITLE
update test_about_contain_image to reflect the doc

### DIFF
--- a/code/tango_with_django_project/rango/tests.py
+++ b/code/tango_with_django_project/rango/tests.py
@@ -52,8 +52,8 @@ class AboutPageTests(TestCase):
         # Check if is there an image on the about page
         # Chapter 4
         response = self.client.get(reverse('about'))
-        self.assertIn(b'img src="/static/images/', response.content)
-        
+        self.assertIn(b'img src="/media/', response.content)
+
     def test_about_using_template(self):
         # Check the template used to render index page
         # Exercise from Chapter 4 


### PR DESCRIPTION
I have updated the test since in the latest version of the book, in chapter 4 (see [manuscript](https://github.com/leifos/tango_with_django_19/blob/master/manuscript/chapter4-templates-static-media.md#modifying-settingspy)), it is suggested to use the `/media/` path in the about page instead of the `/static/` path.