### PR TITLE
Remove unnecessary get_server_side_cookie

### DIFF
--- a/code/tango_with_django_project/rango/views.py
+++ b/code/tango_with_django_project/rango/views.py
@@ -13,20 +13,14 @@ from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth import authenticate, login
 
 # Create your views here.
-def get_server_side_cookie(request, cookie, default_val=None):
-    val = request.session.get(cookie)
-    if not val:
-        val = default_val
-    return val
-
 def visitor_cookie_handler(request):
     # Get the number of visits to the site.
     # We use the COOKIES.get() function to obtain the visits cookie.
     # If the cookie exists, the value returned is casted to an integer.
     # If the cookie doesn't exist, then the default value of 1 is used.
-    visits = int(get_server_side_cookie(request, 'visits', '1'))
+    visits = int(request.session.get('visits', '1'))
 
-    last_visit_cookie = get_server_side_cookie(request, 'last_visit', str(datetime.now()) )
+    last_visit_cookie = request.session.get('last_visit', str(datetime.now()))
 
     last_visit_time = datetime.strptime(last_visit_cookie[:-7], "%Y-%m-%d %H:%M:%S")
     #last_visit_time = datetime.now()

--- a/manuscript/chapter10-cookies.md
+++ b/manuscript/chapter10-cookies.md
@@ -190,19 +190,10 @@ To use the server side data, we need to refactor the code we have written so far
 Since all the cookies are stored server side, we won't be changing the response directly. Because of this, we can remove `response` from the `visitor_cookie_handler()` function definition.
 
 {lang="python",linenos=off}
-	# A helper method
-	def get_server_side_cookie(request, cookie, default_val=None):
-	    val = request.session.get(cookie)
-	    if not val:
-	        val = default_val
-	    return val
-	
 	# Updated the function definition
 	def visitor_cookie_handler(request):
-	    visits = int(get_server_side_cookie(request, 'visits', '1'))
-	    last_visit_cookie = get_server_side_cookie(request,
-	                                               'last_visit',
-	                                               str(datetime.now()))
+	    visits = int(request.session.get('visits', '1'))
+	    last_visit_cookie = request.session.get('last_visit', str(datetime.now()))
 	    last_visit_time = datetime.strptime(last_visit_cookie[:-7],
 	                                        '%Y-%m-%d %H:%M:%S')
 	


### PR DESCRIPTION
Since ```request.session.get(keyword, defaultvalue)``` can already provide default values, ```get_server_side_cookie``` is removed.